### PR TITLE
Prevent loop when parsing log file by skipping bad records.

### DIFF
--- a/src/parse_log.js
+++ b/src/parse_log.js
@@ -23,13 +23,18 @@ class Stats {
     }
 
     addStat(data) {
+        // get hour stamp and check if we have an hourly entry
+        // we need atleast a timestamp to create an entry
+        if (data['time'] === undefined) {
+             return false;
+        }
+
         // skip entries for:
         // "Apache/2.4.25 (FreeBSD) (internal dummy connection)"
         // 408 timeouts as the are health checks from AWS
         //if ((data["remoteHost"].indexOf("172.31") !== -1 && data["status"] == 408) || (data["RequestHeader User-Agent"].indexOf("internal dummy connection") !== -1))
         //    return false;
 
-        // get hour stamp and check if we have an hourly entry
         var hour_stamp = data["time"];
         hour_stamp = hour_stamp.substring(0, hour_stamp.lastIndexOf(':') - 2) + "00";
 
@@ -605,6 +610,9 @@ window.onload = function() {
                             totalBytesRead += data.originalLine.length;
                             previousLogSize += data.originalLine.length + 1;
                             sftpBytesRead.innerHTML = "Total bytes read = " + (totalBytesRead + 1);
+                        }
+                        else {
+                            previousLogSize += data.originalLine.length + 1;                            
                         }
                     }
                     else {

--- a/src/parser/alpine.js
+++ b/src/parser/alpine.js
@@ -50,13 +50,11 @@ function parseReadStream(stream, callback) {
     var thisAlpine = this;
     var stream = byline.createStream(stream);
     stream.pipe(through2.obj(function(chunk, enc, t2callback) {
-        try {
-            var data = thisAlpine.parseLine(chunk.toString());
+        var data = thisAlpine.parseLine(chunk.toString());
+        if (data !== null) {
+            callback(data);
         }
-        catch (err) {
-            callback(null); // parsing error, quit and try again next time.
-        }
-        callback(data);
+
         var ret = t2callback();
     }))
     .on('finish', function () {
@@ -86,13 +84,13 @@ function parseLine(line) {
         var val;
         if (field.isQuoted) {
             if (!(buf.lookingAt() === '"'))
-                throw new Error("Field defined as quoted was not quoted");
+                return null;
             buf.skip();
             val = buf.getUpto('"');
             buf.skip();
         } else if (field.isDate) {
             if (!(buf.lookingAt() === '['))
-                throw new Error("Time field is not enclosed in brackets");
+                return null;
             buf.skip();
             val = buf.getUpto(']');
             buf.skip();


### PR DESCRIPTION
Fix for #5 . This prevents parsing problems by skipping bad records.  Bad records may possibly be incomplete records and need a more robust solution for this.